### PR TITLE
Additional work to auto deploy and build

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,12 +36,6 @@ jobs:
       - name: Adding markdown
         run: cat impact.md >> $GITHUB_STEP_SUMMARY
 
-      - name: Generate makefile
-        run: so -bf make -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
-
-      - name: Deploy to IBM i
-        run: ici --rcwd "./builds/ics_${GITHUB_HEAD_REF}" --push "." --cmd "/QOpenSys/pkgs/bin/gmake LIBL='CMPSYS' BIN_LIB=$(so -bl ${GITHUB_HEAD_REF})"
-
       - name: Post comment
         uses: actions/github-script@v5
         with:
@@ -52,3 +46,13 @@ jobs:
               repo: context.repo.repo,
               body: '👋  A new change report is available based on this PR being created.\n\n[See summary here.](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/${{ github.run_id }})'
             })
+
+      - name: Generate makefile
+        run: so -bf make -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
+
+      - name: Deploy to IBM i
+        run: | 
+          ici \
+            --rcwd "./builds/ics_${GITHUB_HEAD_REF}" \
+            --push "." \
+            --cmd "/QOpenSys/pkgs/bin/gmake LIBL='CMPSYS' BIN_LIB=$(so -bl ${GITHUB_HEAD_REF})"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,12 +25,22 @@ jobs:
       - run: npm i -g @ibm/sourceorbit
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    
+      - run: npm i -g @ibm/ibmi-ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Generate impact information
         run: so -bf imd -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
 
       - name: Adding markdown
         run: cat impact.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate makefile
+        run: so -bf make -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
+
+      - name: Deploy to IBM i
+        run: ici --rcwd "./builds/ics_${GITHUB_HEAD_REF}" --push "." --cmd "/QOpenSys/pkgs/bin/gmake BIN_LIB=$(so -bl ${GITHUB_HEAD_REF})"
 
       - name: Post comment
         uses: actions/github-script@v5

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
         run: so -bf make -l `git diff --name-only origin/main origin/${GITHUB_HEAD_REF}`
 
       - name: Deploy to IBM i
-        run: ici --rcwd "./builds/ics_${GITHUB_HEAD_REF}" --push "." --cmd "/QOpenSys/pkgs/bin/gmake BIN_LIB=$(so -bl ${GITHUB_HEAD_REF})"
+        run: ici --rcwd "./builds/ics_${GITHUB_HEAD_REF}" --push "." --cmd "/QOpenSys/pkgs/bin/gmake LIBL='CMPSYS' BIN_LIB=$(so -bl ${GITHUB_HEAD_REF})"
 
       - name: Post comment
         uses: actions/github-script@v5


### PR DESCRIPTION
Adds ibmi-ci into PR workflow to automatically deploy and build PR into a unique library.

Environment variables need to be setup for this action to deploy to an IBM i.