### PR TITLE
Remove restriction on running PR workflow for when it is just opened

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,6 +34,7 @@ jobs:
             --cmd "mkdir -p './builds/ics_${GITHUB_HEAD_REF}'" \
             --rcwd "./builds/ics_${GITHUB_HEAD_REF}" \
             --push "." \
+            --ignore --cl "CRTLIB CMPSYS" \
             --cmd "/QOpenSys/pkgs/bin/gmake BIN_LIB=CMPSYS"
         env:
           IBMI_HOST: ${{ secrets.IBMI_HOST }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,6 +51,7 @@ jobs:
             --cmd "mkdir -p './builds/ics_${GITHUB_HEAD_REF}'" \
             --rcwd "./builds/ics_${GITHUB_HEAD_REF}" \
             --push "." \
+            --ignore --cl "CRTLIB $(so -bl ${GITHUB_HEAD_REF})" \
             --cmd "/QOpenSys/pkgs/bin/gmake LIBL='CMPSYS' BIN_LIB=$(so -bl ${GITHUB_HEAD_REF})"
         env:
           IBMI_HOST: ${{ secrets.IBMI_HOST }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,8 +1,7 @@
 name: Source Orbit Impact Report
 
 on:
-  pull_request: 
-    types: [opened]
+  pull_request:
 
 jobs:
   so-impact:


### PR DESCRIPTION
@worksofliam I assume this is fine since we want a new impact report to be generated and a build to run when we push more commits after a PR is first opened. Also, creating the build library if it doesn't exist.